### PR TITLE
Adds buildDist to sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,26 @@ libraryDependencies ++= Seq(
     ("org.scalacheck"  % "scalacheck_2.12" % "1.14.0" intransitive()) % "test"
 )
 
+//Build distribution
+val distOutpath             = settingKey[File]("Where to copy all dependencies and kojo")
+val buildDist  = taskKey[Unit]("Copy runtime dependencies and built kojo to 'distOutpath'")
+
+lazy val dist = project
+  .in(file("."))
+  .settings(
+    distOutpath              := baseDirectory.value / "dist",
+    buildDist   := {
+      val allLibs:                List[File]          = dependencyClasspath.in(Runtime).value.map(_.data).filter(_.isFile).toList
+      val buildArtifact:          File                = packageBin.in(Runtime).value
+      val jars:                   List[File]          = buildArtifact :: allLibs
+      val `mappings src->dest`:   List[(File, File)]  = jars.map(f => (f, distOutpath.value / f.getName))
+      val log                                         = streams.value.log
+      log.info(s"Copying to ${distOutpath.value}:")
+      log.info(s"${`mappings src->dest`.map(f => s" * ${f._1}").mkString("\n")}")
+      IO.copy(`mappings src->dest`)
+    }
+  )
+
 //libraryDependencies += "com.novocode" % "junit-interface" % "0.10-M2" % "test"
 
 EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.Resource


### PR DESCRIPTION
This allows you to run:
./sbt.sh buildDist

Which will build Kojo and then copy all dependencies and the built artifact into a dist/ folder.
This folder can then be used to build the classpath and an installer.

It includes the unmanaged dependencies when I tested it and only runtime dependencies, test dependencies are excluded.