### PR TITLE
Supporting scaling on both axes for withScaling method.

### DIFF
--- a/src/main/scala/net/kogics/kojo/core/Picture.scala
+++ b/src/main/scala/net/kogics/kojo/core/Picture.scala
@@ -25,6 +25,7 @@ trait Picture extends InputAware {
   def rotateAboutPoint(angle: Double, x: Double, y: Double): Unit
   def scale(factor: Double): Unit
   def scaleAboutPoint(factor: Double, x: Double, y: Double): Unit
+  def scaleAboutPoint(factorX: Double, factorY: Double, x: Double, y: Double): Unit
   def scale(xFactor: Double, yFactor: Double): Unit
   def translate(x: Double, y: Double): Unit
   def translate(v: Vector2D): Unit = translate(v.x, v.y): Unit
@@ -178,7 +179,9 @@ trait Picture extends InputAware {
   def withRotationAround(angle: Double, x: Double, y: Double): Picture
   def withTranslation(x: Double, y: Double): Picture
   def withScaling(factor: Double): Picture
+  def withScaling(factorX: Double, factorY: Double): Picture
   def withScalingAround(factor: Double, x: Double, y: Double): Picture
+  def withScalingAround(factorX: Double, factorY: Double, x: Double, y: Double): Picture
   def withFillColor(color: Paint): Picture
   def withPenColor(color: Paint): Picture
   def withPenThickness(t: Double): Picture

--- a/src/main/scala/net/kogics/kojo/picture/pics.scala
+++ b/src/main/scala/net/kogics/kojo/picture/pics.scala
@@ -130,6 +130,12 @@ trait CorePicOps extends GeomPolygon with UnsupportedOps { self: Picture with Re
     translate(-x, -y)
   }
 
+  def scaleAboutPoint(factorX: Double, factorY: Double, x: Double, y: Double): Unit = {
+    translate(x, y)
+    scale(factorX, factorY)
+    translate(-x, -y)
+  }
+
   def scale(xFactor: Double, yFactor: Double): Unit = {
     transformBy(AffineTransform.getScaleInstance(safeScaleFactor(xFactor), safeScaleFactor(yFactor)))
   }
@@ -395,8 +401,12 @@ trait CorePicOps2 extends GeomPolygon { self: Picture =>
     PostDrawTransform { pic => pic.rotateAboutPoint(angle, x, y) }(this)
   def withTranslation(x: Double, y: Double): Picture = PostDrawTransform { pic => pic.translate(x, y) }(this)
   def withScaling(factor: Double): Picture = PostDrawTransform { pic => pic.scale(factor) }(this)
+  def withScaling(factorX: Double, factorY: Double): Picture =
+    PostDrawTransform { pic => pic.scale(factorX, factorY) }(this)
   def withScalingAround(factor: Double, x: Double, y: Double): Picture =
     PostDrawTransform { pic => pic.scaleAboutPoint(factor, x, y) }(this)
+  def withScalingAround(factorX: Double, factorY: Double, x: Double, y: Double): Picture =
+    PostDrawTransform { pic => pic.scaleAboutPoint(factorX, factorY, x, y) }(this)
   def withFillColor(color: Paint): Picture = PostDrawTransform { pic => pic.setFillColor(color) }(this)
   def withPenColor(color: Paint): Picture = PostDrawTransform { pic => pic.setPenColor(color) }(this)
   def withPenThickness(t: Double): Picture = PostDrawTransform { pic => pic.setPenThickness(t) }(this)

--- a/src/main/scala/net/kogics/kojo/picture/transforms.scala
+++ b/src/main/scala/net/kogics/kojo/picture/transforms.scala
@@ -34,6 +34,7 @@ trait Transformer extends Picture with CorePicOps2 {
   def rotateAboutPoint(angle: Double, x: Double, y: Double) = tpic.rotateAboutPoint(angle, x, y)
   def scale(factor: Double) = tpic.scale(factor)
   def scaleAboutPoint(factor: Double, x: Double, y: Double) = tpic.scaleAboutPoint(factor, x, y)
+  def scaleAboutPoint(factorX: Double, factorY: Double, x: Double, y: Double) = tpic.scaleAboutPoint(factorX, factorY, x, y)
   def scale(xFactor: Double, yFactor: Double) = tpic.scale(xFactor, yFactor)
   def opacityMod(f: Double) = tpic.opacityMod(f)
   def hueMod(f: Double) = tpic.hueMod(f)


### PR DESCRIPTION
Currently, Kojo supports scaling on both axes for Pictures using the transforms. However, the new with* transforms has a scaling function that scales both the axes equally. This change supports the double axes scaling using with* transforms. 