### PR TITLE
Added a Shear transform for pictures

### DIFF
--- a/src/main/scala/net/kogics/kojo/core/Picture.scala
+++ b/src/main/scala/net/kogics/kojo/core/Picture.scala
@@ -27,6 +27,7 @@ trait Picture extends InputAware {
   def scaleAboutPoint(factor: Double, x: Double, y: Double): Unit
   def scaleAboutPoint(factorX: Double, factorY: Double, x: Double, y: Double): Unit
   def scale(xFactor: Double, yFactor: Double): Unit
+  def shear(shearX:Double, shearY:Double):Unit
   def translate(x: Double, y: Double): Unit
   def translate(v: Vector2D): Unit = translate(v.x, v.y): Unit
   def transv(v: Vector2D) = translate(v.x, v.y): Unit
@@ -182,6 +183,7 @@ trait Picture extends InputAware {
   def withScaling(factorX: Double, factorY: Double): Picture
   def withScalingAround(factor: Double, x: Double, y: Double): Picture
   def withScalingAround(factorX: Double, factorY: Double, x: Double, y: Double): Picture
+  def withShear(shearX:Double, shearY:Double):Picture
   def withFillColor(color: Paint): Picture
   def withPenColor(color: Paint): Picture
   def withPenThickness(t: Double): Picture

--- a/src/main/scala/net/kogics/kojo/picture/pics.scala
+++ b/src/main/scala/net/kogics/kojo/picture/pics.scala
@@ -140,6 +140,10 @@ trait CorePicOps extends GeomPolygon with UnsupportedOps { self: Picture with Re
     transformBy(AffineTransform.getScaleInstance(safeScaleFactor(xFactor), safeScaleFactor(yFactor)))
   }
 
+  def shear(shearX:Double, shearY:Double):Unit = {
+    transformBy(AffineTransform.getShearInstance(shearX, shearY))
+  }
+
   def translate(x: Double, y: Double): Unit = {
     transformBy(AffineTransform.getTranslateInstance(x, y))
   }
@@ -407,6 +411,8 @@ trait CorePicOps2 extends GeomPolygon { self: Picture =>
     PostDrawTransform { pic => pic.scaleAboutPoint(factor, x, y) }(this)
   def withScalingAround(factorX: Double, factorY: Double, x: Double, y: Double): Picture =
     PostDrawTransform { pic => pic.scaleAboutPoint(factorX, factorY, x, y) }(this)
+  def withShear(shearX:Double, shearY:Double):Picture =
+    PostDrawTransform { pic => pic.shear(shearX, shearY) }(this)
   def withFillColor(color: Paint): Picture = PostDrawTransform { pic => pic.setFillColor(color) }(this)
   def withPenColor(color: Paint): Picture = PostDrawTransform { pic => pic.setPenColor(color) }(this)
   def withPenThickness(t: Double): Picture = PostDrawTransform { pic => pic.setPenThickness(t) }(this)

--- a/src/main/scala/net/kogics/kojo/picture/transforms.scala
+++ b/src/main/scala/net/kogics/kojo/picture/transforms.scala
@@ -36,6 +36,7 @@ trait Transformer extends Picture with CorePicOps2 {
   def scaleAboutPoint(factor: Double, x: Double, y: Double) = tpic.scaleAboutPoint(factor, x, y)
   def scaleAboutPoint(factorX: Double, factorY: Double, x: Double, y: Double) = tpic.scaleAboutPoint(factorX, factorY, x, y)
   def scale(xFactor: Double, yFactor: Double) = tpic.scale(xFactor, yFactor)
+  def shear(shearX:Double, shearY:Double):Unit = tpic.shear(shearX, shearY)
   def opacityMod(f: Double) = tpic.opacityMod(f)
   def hueMod(f: Double) = tpic.hueMod(f)
   def satMod(f: Double) = tpic.satMod(f)


### PR DESCRIPTION
Like rotate/scale and transpose, shear transform can be used to build complex pictures from simple shapes. For example, we can make a right-angled triangle using an equilateral triangle. Refer to the following example for reference on how this transform can be used. 

<img width="1404" alt="KojoShearTransform" src="https://user-images.githubusercontent.com/304747/154449702-4ab75aee-a964-4253-8920-78ccba68f981.png">
 