### PR TITLE
Adding transforms which work as PreDrawTransforms

### DIFF
--- a/src/main/scala/net/kogics/kojo/core/Picture.scala
+++ b/src/main/scala/net/kogics/kojo/core/Picture.scala
@@ -176,6 +176,7 @@ trait Picture extends InputAware {
     val pos0 = position
     animateToPosition(pos0.x + dx, pos0.y + dy, inMillis)(onEnd)
   }
+
   def withRotation(angle: Double): Picture
   def withRotationAround(angle: Double, x: Double, y: Double): Picture
   def withTranslation(x: Double, y: Double): Picture
@@ -187,6 +188,20 @@ trait Picture extends InputAware {
   def withFillColor(color: Paint): Picture
   def withPenColor(color: Paint): Picture
   def withPenThickness(t: Double): Picture
+
+  // Transforms that are applied before drawing
+  def thatsRotated(angle: Double): Picture
+  def thatsRotatedAround(angle: Double, x: Double, y: Double): Picture
+  def thatsTranslated(x: Double, y: Double): Picture
+  def thatsScaled(factor: Double): Picture
+  def thatsScaled(factorX: Double, factorY: Double): Picture
+  def thatsScaledAround(factor: Double, x: Double, y: Double): Picture
+  def thatsScaledAround(factorX: Double, factorY: Double, x: Double, y: Double): Picture
+  def thatsSheared(shearX:Double, shearY:Double):Picture
+  def thatsFilledWith(color: Paint): Picture
+  def thatsStrokeColored(color: Paint): Picture
+  def thatsStrokeSized(t: Double): Picture
+
   def withEffect(filter: BufferedImageOp): Picture
   def withEffect(filter: ImageOp): Picture
   def withFlippedX: Picture

--- a/src/main/scala/net/kogics/kojo/picture/pics.scala
+++ b/src/main/scala/net/kogics/kojo/picture/pics.scala
@@ -416,6 +416,25 @@ trait CorePicOps2 extends GeomPolygon { self: Picture =>
   def withFillColor(color: Paint): Picture = PostDrawTransform { pic => pic.setFillColor(color) }(this)
   def withPenColor(color: Paint): Picture = PostDrawTransform { pic => pic.setPenColor(color) }(this)
   def withPenThickness(t: Double): Picture = PostDrawTransform { pic => pic.setPenThickness(t) }(this)
+
+  // Transforms that are applied before drawing
+  def thatsRotated(angle: Double): Picture = PreDrawTransform { pic => pic.rotate(angle) }(this)
+  def thatsRotatedAround(angle: Double, x: Double, y: Double): Picture =
+    PreDrawTransform { pic => pic.rotateAboutPoint(angle, x, y) }(this)
+  def thatsTranslated(x: Double, y: Double): Picture = PreDrawTransform { pic => pic.translate(x, y) }(this)
+  def thatsScaled(factor: Double): Picture = PreDrawTransform { pic => pic.scale(factor) }(this)
+  def thatsScaled(factorX: Double, factorY: Double): Picture =
+    PreDrawTransform { pic => pic.scale(factorX, factorY) }(this)
+  def thatsScaledAround(factor: Double, x: Double, y: Double): Picture =
+    PreDrawTransform { pic => pic.scaleAboutPoint(factor, x, y) }(this)
+  def thatsScaledAround(factorX: Double, factorY: Double, x: Double, y: Double): Picture =
+    PreDrawTransform { pic => pic.scaleAboutPoint(factorX, factorY, x, y) }(this)
+  def thatsSheared(shearX:Double, shearY:Double):Picture =
+    PreDrawTransform { pic => pic.shear(shearX, shearY) }(this)
+  def thatsFilledWith(color: Paint): Picture = PostDrawTransform { pic => pic.setFillColor(color) }(this)
+  def thatsStrokeColored(color: Paint): Picture = PostDrawTransform { pic => pic.setPenColor(color) }(this)
+  def thatsStrokeSized(t: Double): Picture = PostDrawTransform { pic => pic.setPenThickness(t) }(this)
+
   def withEffect(filter: BufferedImageOp): Picture = ApplyFilter(filter)(epic(this))
 
   def withEffect(filterOp: ImageOp): Picture = {


### PR DESCRIPTION
This is to make transform methods more readable and refactorable. Refer to attached example:


[DragonFlyWithTweaks.txt](https://github.com/litan/kojo/files/8096944/DragonFlyWithTweaks.txt)

