### PR TITLE
Turkish localization refresh: tr API layer, samples, and bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ log
 .bloop
 .metals
 .vscode
+scala-en-jars/
+

--- a/installer.i4j/kojo.install4j
+++ b/installer.i4j/kojo.install4j
@@ -47,6 +47,7 @@
       <java mainClass="net.kogics.kojo.lite.DesktopMain">
         <classPath>
           <scanDirectory location="lib" failOnError="false" />
+          <scanDirectory location="lib/scala-en" failOnError="false" />
         </classPath>
       </java>
       <vmOptionsFile mode="none" />

--- a/installer/bin/kojo
+++ b/installer/bin/kojo
@@ -7,10 +7,14 @@ JAVA=java
 # export _JAVA_OPTIONS="-Dsun.java2d.xrender=false"
 
 BIN_DIR=`dirname $0`
-FILES=$BIN_DIR/../lib/*
+# The launcher always boots on the stock Scala toolchain in lib/scala-en;
+# DesktopMain swaps in lib/scala-tr for the real Kojo JVM when the user
+# language is Turkish (see net.kogics.kojo.lite.ScalaToolchain).
+FILES="$BIN_DIR/../lib/* $BIN_DIR/../lib/scala-en/*"
 CLASSPATH=
 for f in $FILES
 do
+  [ -f "$f" ] || continue
   CLASSPATH=${CLASSPATH}:$f
 done
 

--- a/installer/bin/kojo.cmd
+++ b/installer/bin/kojo.cmd
@@ -3,7 +3,12 @@ SET kojolibdir="..\lib"
 SET kojojavacp=
 SETLOCAL EnableDelayedExpansion
 echo %kojolibdir%
-FOR %%A IN (%kojolibdir%\*) DO ( 
+FOR %%A IN (%kojolibdir%\*) DO (
+  SET kojojavacp=!kojojavacp!;%%~A
+)
+REM launcher boots on the stock Scala toolchain; DesktopMain swaps in
+REM lib\scala-tr for the real Kojo JVM when the user language is Turkish
+FOR %%A IN (%kojolibdir%\scala-en\*) DO (
   SET kojojavacp=!kojojavacp!;%%~A
 )
 echo %kojojavacp%

--- a/installer/jarlist.txt
+++ b/installer/jarlist.txt
@@ -2,7 +2,6 @@
 ../dist/rsyntaxtextarea.jar
 ../dist/rstaui.jar
 ../dist/autocomplete.jar
-../dist/scalariform.jar
 ../dist/docking-frames-common.jar
 ../dist/jl1.0.1.jar
 ../dist/jlatexmath.jar
@@ -15,7 +14,6 @@
 ../dist/jssc.jar
 ../dist/flatlaf-3.4.jar -> flatlaf.jar
 ../dist/libtiled.jar
-../dist/scala-reflect-2.13.18.jar -> scala-reflect.jar
 ../dist/akka-actor_2.13-2.6.16.jar -> akka-actors.jar
 ../dist/scala-swing_2.13-2.1.1.jar -> scala-swing.jar
 ../dist/scala-xml_2.13-1.2.0.jar -> scala-xml.jar
@@ -26,8 +24,6 @@
 ../dist/h2-1.3.168.jar -> h2.jar
 ../dist/scalatest_2.13-3.0.8.jar -> scalatest.jar
 ../dist/scalactic_2.13-3.0.8.jar -> scalactic.jar
-../dist/scala-library-2.13.18.jar -> scala-library.jar
-../dist/scala-compiler-2.13.18.jar -> scala-compiler.jar
 ../dist/config-1.4.0.jar -> config.jar
 ../dist/scala-java8-compat_2.13-1.0.0.jar -> scala-java8-compat.jar
 ../dist/activation-1.1.jar -> activation.jar
@@ -41,3 +37,4 @@
 ../dist/httpcore5-h2-5.1.3.jar -> httpcore5-h2.jar
 ../dist/slf4j-api-1.7.25.jar -> slf4j-api.jar
 ../dist/slf4j-jdk14-1.7.25.jar -> slf4j-jdk14.jar
+../dist/scala-parallel-collections_2.13-1.2.0.jar -> scala-parallel-collections_2.13-1.2.0.jar

--- a/installer/winlauncher-for-zip.xml
+++ b/installer/winlauncher-for-zip.xml
@@ -17,6 +17,7 @@
   <classPath>
     <mainClass>net.kogics.kojo.lite.DesktopMain</mainClass>
     <cp>../lib/*.jar</cp>
+    <cp>../lib/scala-en/*.jar</cp>
   </classPath>
   <jre>
     <path>../jre</path>

--- a/make-windows-zip.sh
+++ b/make-windows-zip.sh
@@ -12,6 +12,17 @@ cd installer
 scala cp-staging-jars.scala
 cd ..
 
+# Stage the stock Scala toolchain into lib/scala-en; the launcher boots on it.
+# The Turkish-keyword toolchain is not packaged - it is fetched on demand.
+./stage-scala-toolchains.sh installerbuild/lib
+
+# The committed launch4j exe has its classpath baked in; warn if it predates
+# the lib/scala-en entry, since such a build ships a launcher that cannot find Scala.
+if ! grep -q "scala-en" installer/bin/kojo.exe 2>/dev/null; then
+  echo "[WARNING] installer/bin/kojo.exe has no lib/scala-en classpath entry -" >&2
+  echo "[WARNING] regenerate it from installer/winlauncher-for-zip.xml with launch4j." >&2
+fi
+
 cp -va installer/* installerbuild/
 cd installerbuild
 rm *.*

--- a/makezip.sh
+++ b/makezip.sh
@@ -12,6 +12,17 @@ cd installer
 scala cp-staging-jars.scala
 cd ..
 
+# Stage the stock Scala toolchain into lib/scala-en; the launcher boots on it.
+# The Turkish-keyword toolchain is not packaged - it is fetched on demand.
+./stage-scala-toolchains.sh installerbuild/lib
+
+# The committed launch4j exe has its classpath baked in; warn if it predates
+# the lib/scala-en entry, since such a build ships a launcher that cannot find Scala.
+if ! grep -q "scala-en" installer/bin/kojo.exe 2>/dev/null; then
+  echo "[WARNING] installer/bin/kojo.exe has no lib/scala-en classpath entry -" >&2
+  echo "[WARNING] regenerate it from installer/winlauncher-for-zip.xml with launch4j." >&2
+fi
+
 cp -va installer/* installerbuild/
 cd installerbuild
 rm *.*

--- a/src/main/scala/net/kogics/kojo/lite/DesktopMain.scala
+++ b/src/main/scala/net/kogics/kojo/lite/DesktopMain.scala
@@ -19,6 +19,6 @@ import java.io.File
 object DesktopMain extends StubMain with RmiMultiInstance {
   lazy val classpath = {
     val cp = System.getProperty("java.class.path").split(File.pathSeparatorChar).toList
-    createCp(cp)
+    createCp(ScalaToolchain.select(cp))
   }
 }

--- a/src/main/scala/net/kogics/kojo/lite/FetchProgress.scala
+++ b/src/main/scala/net/kogics/kojo/lite/FetchProgress.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026
+ *   Bulent Basaran <ben@scala.org> https://github.com/bulent2k2
+ *
+ * The contents of this file are subject to the GNU General Public License
+ * Version 3 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.gnu.org/copyleft/gpl.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ */
+package net.kogics.kojo.lite
+
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.GraphicsEnvironment
+
+import javax.swing.border.EmptyBorder
+import javax.swing.BoxLayout
+import javax.swing.JDialog
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JProgressBar
+import javax.swing.SwingUtilities
+import javax.swing.WindowConstants
+
+/** How the toolchain download reports itself. */
+trait FetchProgress {
+  def message(msg: String): Unit
+  def startJar(name: String, totalBytes: Long): Unit
+  def bytes(n: Long): Unit
+  def finished(): Unit
+}
+
+/** The default: just log. Used by the tests and by headless runs. */
+object ConsoleProgress extends FetchProgress {
+  def message(msg: String): Unit = println(msg)
+  def startJar(name: String, totalBytes: Long): Unit = println(s"[INFO] ... $name")
+  def bytes(n: Long): Unit = ()
+  def finished(): Unit = ()
+}
+
+/**
+ * A small progress window for the launcher JVM, which has no Kojo UI yet -
+ * StubMain already puts up a JOptionPane there for the Java version check.
+ *
+ * The text is Turkish because this download only ever happens for a user who
+ * has chosen Turkish; the log line alongside it stays in English.
+ *
+ * Every UI touch is posted to the EDT (never invokeAndWait, so a slow or
+ * missing display can't wedge the download), and bar updates are throttled,
+ * so a 20 MB fetch doesn't flood the event queue with repaints.
+ */
+class SwingFetchProgress extends FetchProgress {
+  private var dialog: JDialog = _
+  private var bar: JProgressBar = _
+  private var label: JLabel = _
+  private var received = 0L
+  private var total = 0L
+  private var lastPainted = 0L
+
+  private def onEdt(body: => Unit): Unit = SwingUtilities.invokeLater(new Runnable {
+    def run(): Unit = body
+  })
+
+  private def ensureDialog(): Unit = onEdt {
+    if (dialog == null) {
+      label = new JLabel("Türkçe Scala derleyicisi indiriliyor...")
+      bar = new JProgressBar(0, 100)
+      bar.setIndeterminate(true)
+      bar.setPreferredSize(new Dimension(320, 18))
+      val content = new JPanel()
+      content.setLayout(new BoxLayout(content, BoxLayout.Y_AXIS))
+      content.setBorder(new EmptyBorder(14, 16, 14, 16))
+      content.add(label)
+      content.add(javax.swing.Box.createVerticalStrut(10))
+      content.add(bar)
+      dialog = new JDialog(null: java.awt.Frame, "Kojo", false)
+      dialog.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE)
+      dialog.getContentPane.add(content, BorderLayout.CENTER)
+      dialog.pack()
+      dialog.setLocationRelativeTo(null)
+      dialog.setVisible(true)
+    }
+  }
+
+  def message(msg: String): Unit = println(msg)
+
+  def startJar(name: String, totalBytes: Long): Unit = {
+    println(s"[INFO] ... $name")
+    received = 0L
+    total = totalBytes
+    lastPainted = 0L
+    ensureDialog()
+    onEdt {
+      if (label != null) label.setText(s"Türkçe Scala derleyicisi indiriliyor: $name")
+      if (bar != null) {
+        bar.setIndeterminate(totalBytes <= 0)
+        if (totalBytes > 0) bar.setValue(0)
+      }
+    }
+  }
+
+  def bytes(n: Long): Unit = {
+    received += n
+    // repaint at most once per percent, and only when the size is known
+    if (total > 0) {
+      val pct = (received * 100 / total).toInt
+      if (pct != lastPainted) {
+        lastPainted = pct
+        onEdt(if (bar != null) bar.setValue(pct))
+      }
+    }
+  }
+
+  def finished(): Unit = onEdt {
+    if (dialog != null) {
+      dialog.setVisible(false)
+      dialog.dispose()
+      dialog = null
+    }
+  }
+}
+
+object FetchProgress {
+
+  /** A window when there is a display to put it on, plain logging otherwise. */
+  def forLauncher(): FetchProgress =
+    if (GraphicsEnvironment.isHeadless) ConsoleProgress
+    else
+      try new SwingFetchProgress
+      catch { case _: Throwable => ConsoleProgress }
+}

--- a/src/main/scala/net/kogics/kojo/lite/Main.scala
+++ b/src/main/scala/net/kogics/kojo/lite/Main.scala
@@ -81,6 +81,10 @@ object Main extends AppMenu with ScriptLoader { main =>
 
     setupLogging()
     val Log = Logger.getLogger("Main")
+    ScalaToolchainCheck.versionMismatch.foreach { msg =>
+      Log.warning(msg)
+      System.err.println(s"[WARNING] $msg")
+    }
     if (!kojoCtx.subKojo) {
       runMultiInstancehandler()
     }

--- a/src/main/scala/net/kogics/kojo/lite/NewKojoInstance.scala
+++ b/src/main/scala/net/kogics/kojo/lite/NewKojoInstance.scala
@@ -5,7 +5,7 @@ import java.io.File
 object NewKojoInstance extends StubMain {
   lazy val classpath = {
     val cp = System.getProperty("java.class.path").split(File.pathSeparatorChar).toList
-    createCp(cp)
+    createCp(ScalaToolchain.select(cp))
   }
 
   def firstInstance = true

--- a/src/main/scala/net/kogics/kojo/lite/ScalaToolchain.scala
+++ b/src/main/scala/net/kogics/kojo/lite/ScalaToolchain.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026
+ *   Bulent Basaran <ben@scala.org> https://github.com/bulent2k2
+ *
+ * The contents of this file are subject to the GNU General Public License
+ * Version 3 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.gnu.org/copyleft/gpl.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ */
+package net.kogics.kojo.lite
+
+import java.io.File
+import java.util.prefs.Preferences
+
+import net.kogics.kojo.util.Utils
+
+/**
+ * Picks the Scala toolchain for the real Kojo JVM, so that Turkish users get
+ * the compiler patched with Turkish keywords and everybody else gets the
+ * stock one.
+ *
+ * A packaged Kojo ships two toolchain directories next to the regular jars:
+ *   - lib/scala-en: stock scala-library, scala-reflect, scala-compiler and
+ *     scalariform jars (English and all other non-Turkish languages), at the
+ *     same Scala version the patched jars were built from (staged by
+ *     stage-scala-toolchains.sh)
+ *   - lib/scala-tr: the Turkish-keyword-patched build of the same four jars
+ *     (dez=val, den=var, tanim=def, ...)
+ *
+ * The launcher JVM always boots on lib/scala-en (see installer/bin/kojo and
+ * friends). Before spawning the real Kojo JVM, `select` swaps the toolchain
+ * entries on the classpath for the ones matching the persisted user language
+ * (the same "Kojolite-Prefs"/"user.language" preference that KojoCtx writes;
+ * a language change already requires a Kojo restart, which relaunches this
+ * launcher). -Dkojo.toolchain=en|tr overrides the language-based choice, and
+ * a kojo.toolchain entry in the per-install kojo.properties does the same
+ * (the Koco install4j package sets -Dkojo.toolchain=tr, so it compiles
+ * Turkish keywords out of the box even before a language preference exists).
+ *
+ * If no toolchain directory is on the launcher classpath - e.g. a dev run
+ * via sbt, where scalaHome pins the toolchain, or an old-style package -
+ * the classpath is left untouched.
+ */
+object ScalaToolchain {
+  val englishDirName = "scala-en"
+  val turkishDirName = "scala-tr"
+  private val variantDirNames = Set(englishDirName, turkishDirName)
+  val prefsNodeName = "Kojolite-Prefs" // keep in sync with KojoCtx.prefs
+
+  def userLanguage: String = {
+    val default = System.getProperty("user.language", "en")
+    try {
+      Preferences.userRoot().node(prefsNodeName).get("user.language", default)
+    }
+    catch {
+      case _: Exception => default // prefs can be unavailable in sandboxed/headless setups
+    }
+  }
+
+  private def parseOverride(value: String, source: String): Option[String] = value match {
+    case "en" => Some(englishDirName)
+    case "tr" => Some(turkishDirName)
+    case other =>
+      println(s"[WARNING] Ignoring unknown kojo.toolchain '$other' (from $source); expected 'en' or 'tr'.")
+      None
+  }
+
+  def variantDirName: String = {
+    val fromSysProp = Option(System.getProperty("kojo.toolchain")).flatMap(parseOverride(_, "system property"))
+    def fromAppProp = Utils.appProperty("kojo.toolchain").flatMap(parseOverride(_, "kojo.properties"))
+    def fromLanguage = if (userLanguage == "tr") turkishDirName else englishDirName
+    fromSysProp.orElse(fromAppProp).getOrElse(fromLanguage)
+  }
+
+
+  /**
+   * The Scala release Kojo is running on, e.g. "2.13.18" - taken from the
+   * compiler on the launcher classpath. compiler.properties is not shaded by
+   * anything else in lib/, unlike library.properties (scalariform bundles a
+   * copy of that one).
+   */
+  def scalaRelease: Option[String] =
+    try """(\d+\.\d+\.\d+)""".r.findFirstIn(scala.tools.nsc.Properties.versionNumberString)
+    catch { case _: Throwable => None }
+
+  /**
+   * Where the jars of `variant` live. Normally the directory shipped inside the
+   * package; when the Turkish toolchain was not packaged (the on-demand case),
+   * the copy under ~/.kojo/lite/scala-tr, fetching it if this is the first time.
+   */
+  private def resolveVariantDir(packaged: File, variant: String): File = {
+    def packagedHasJars = Utils.filesInDir(packaged.getPath, "jar").nonEmpty
+    if (variant != turkishDirName || packagedHasJars) packaged
+    else
+      scalaRelease
+        .flatMap(v => ScalaToolchainFetcher.ensureAvailable(v, FetchProgress.forLauncher()))
+        .getOrElse {
+          println("[WARNING] The Turkish Scala toolchain is not available; falling back to the stock one.")
+          packaged
+        }
+  }
+
+  def select(cp: List[String]): List[String] = select(cp, variantDirName)
+
+  def select(cp: List[String], variant: String): List[String] = {
+    def variantParent(entry: String): Option[File] =
+      Option(new File(entry).getParentFile).filter(dir => variantDirNames.contains(dir.getName))
+
+    val toolchainRoots = cp.flatMap(e => variantParent(e).flatMap(dir => Option(dir.getParentFile))).distinct
+    toolchainRoots match {
+      case Nil => cp
+      case root :: _ =>
+        val variantDir = resolveVariantDir(new File(root, variant), variant)
+        val jars = Utils.filesInDir(variantDir.getPath, "jar").sorted.map(new File(variantDir, _).getPath)
+        if (jars.isEmpty) {
+          println(s"[WARNING] No Scala toolchain jars found in $variantDir; classpath left unchanged.")
+          cp
+        }
+        else {
+          val overrideProp = System.getProperty("kojo.toolchain", "<unset>")
+          println(s"[INFO] Scala toolchain: $variantDir (user language '$userLanguage', kojo.toolchain=$overrideProp)")
+          val expected = Set("scala-library.jar", "scala-reflect.jar", "scala-compiler.jar", "scalariform.jar")
+          val missing = expected -- jars.map(new File(_).getName).toSet
+          if (missing.nonEmpty) {
+            println(s"[WARNING] Incomplete Scala toolchain in $variantDir; missing: ${missing.mkString(", ")}")
+          }
+          jars ::: cp.filterNot(e => variantParent(e).isDefined)
+        }
+    }
+  }
+}

--- a/src/main/scala/net/kogics/kojo/lite/ScalaToolchainCheck.scala
+++ b/src/main/scala/net/kogics/kojo/lite/ScalaToolchainCheck.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026
+ *   Bulent Basaran <ben@scala.org> https://github.com/bulent2k2
+ *
+ * The contents of this file are subject to the GNU General Public License
+ * Version 3 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.gnu.org/copyleft/gpl.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ */
+package net.kogics.kojo.lite
+
+import java.io.File
+
+/**
+ * Guards against a stray Scala toolchain jar shadowing the one Kojo ships.
+ *
+ * `StubMain.createCp` puts user-supplied jars - from ~/.kojo/lite/libk, the
+ * extension dirs and KOJO_CLASSPATH - ahead of Kojo's own lib directory. A
+ * scala-library, scala-reflect, scala-compiler or scalariform jar sitting in
+ * one of those places therefore wins over Kojo's copy, and the mismatched
+ * pair fails much later, deep inside the compiler, with an inscrutable error
+ * (a scala-library-2.13.3.jar left in libk produced
+ * `NoSuchMethodError: MurmurHash3$.caseClassHash(...)` at startup).
+ *
+ * Two guards live here: a name test used to skip such jars while the
+ * classpath is being built, and a startup check that reports a toolchain
+ * that is already mixed, naming the jar each part came from.
+ */
+object ScalaToolchainCheck {
+  private val toolchainJarPrefixes = Seq("scala-library", "scala-reflect", "scala-compiler", "scalariform")
+
+  /**
+   * True for scala-library.jar, scala-library-2.13.3.jar and friends - but not
+   * for scala-swing_2.13-*.jar, scalatest_2.13-*.jar and other jars that merely
+   * start with the same letters.
+   */
+  def isToolchainJarName(name: String): Boolean =
+    name.endsWith(".jar") && toolchainJarPrefixes.exists { p =>
+      name == s"$p.jar" || name.startsWith(s"$p-")
+    }
+
+  /** Splits classpath entries into (toolchain jars, everything else). */
+  def partitionStrays(entries: List[String]): (List[String], List[String]) =
+    entries.partition(e => isToolchainJarName(new File(e).getName))
+
+
+  private def versionAt(url: String): Option[String] =
+    try {
+      val is = new java.net.URL(url).openStream()
+      try {
+        val props = new java.util.Properties()
+        props.load(is)
+        Option(props.getProperty("version.number")).filter(_.nonEmpty)
+      }
+      finally is.close()
+    }
+    catch { case _: Throwable => None }
+
+  private def part(name: String, propsFile: String, preferInUrl: String): Option[(String, String, String)] = {
+    val urls = collection.mutable.ListBuffer.empty[String]
+    val e = getClass.getClassLoader.getResources(propsFile)
+    while (e.hasMoreElements) urls += e.nextElement.toString
+    // upstream's scalariform.jar bundles its own (2.13.0) library.properties, so the
+    // first hit for a properties file is not always the artifact we are asking about
+    val url = urls.find(_.contains(preferInUrl)).orElse(urls.headOption)
+    url.flatMap(u => versionAt(u).map(v => (name, v, u)))
+  }
+
+  /**
+   * Detects a mixed Scala toolchain - a scala-library, scala-reflect and
+   * scala-compiler of different versions resolving from different jars.
+   * Reports the jar each part came from, without loading the compiler's
+   * heavyweight classes just to ask.
+   */
+  def versionMismatch: Option[String] =
+    try {
+      val parts = Seq(
+        part("scala-library", "library.properties", "scala-library"),
+        part("scala-reflect", "reflect.properties", "scala-reflect"),
+        part("scala-compiler", "compiler.properties", "scala-compiler")
+      ).flatten
+
+      if (parts.map(_._2).distinct.size <= 1) None
+      else
+        Some(
+          "Mixed Scala toolchain on the classpath - Kojo will likely fail to compile scripts:\n" +
+            parts.map { case (name, version, source) => s"  $name $version from $source" }.mkString("\n") +
+            "\nRemove the stray jar(s) - check ~/.kojo/lite/libk, ~/.kojo/extension, the KOJO_CLASSPATH " +
+            "environment variable, and old scala jars in the install's lib directory."
+        )
+    }
+    catch {
+      // a broken classpath is exactly what this check looks for; it must not
+      // fail startup itself while trying to describe one
+      case _: Throwable => None
+    }
+
+}

--- a/src/main/scala/net/kogics/kojo/lite/ScalaToolchainFetcher.scala
+++ b/src/main/scala/net/kogics/kojo/lite/ScalaToolchainFetcher.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2026
+ *   Bulent Basaran <ben@scala.org> https://github.com/bulent2k2
+ *
+ * The contents of this file are subject to the GNU General Public License
+ * Version 3 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.gnu.org/copyleft/gpl.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ */
+package net.kogics.kojo.lite
+
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.net.URL
+import java.security.MessageDigest
+import java.util.zip.ZipFile
+
+import scala.io.Source
+
+import net.kogics.kojo.util.Utils
+
+/**
+ * Fetches the Turkish-keyword Scala toolchain on demand, so that a Kojo
+ * package does not have to carry ~20 MB of patched compiler that only
+ * Turkish users ever load.
+ *
+ * The jars land in ~/.kojo/lite/scala-tr/<version>/ - user-writable, so no
+ * admin rights are needed and the download survives a reinstall. Nothing is
+ * fetched unless the Turkish toolchain is actually selected (by user
+ * language or by -Dkojo.toolchain=tr), and a failure is never fatal: Kojo
+ * falls back to the stock toolchain and says why.
+ *
+ * Every downloaded jar must clear three checks before it is used:
+ *   - its SHA-256 matches the published SHA256SUMS
+ *   - it opens as a zip (a truncated download fails here, not at runtime)
+ *   - scala-library.jar reports the Scala version Kojo was built against,
+ *     so a toolchain from a different Scala release can never be paired
+ *     with Kojo's classes
+ *
+ * -Dkojo.toolchain.url=<base> overrides the download location, which is how
+ * the tests drive the whole path from a local directory, offline.
+ */
+object ScalaToolchainFetcher {
+  val jarNames = Seq("scala-library.jar", "scala-reflect.jar", "scala-compiler.jar", "scalariform.jar")
+  val checksumFileName = "SHA256SUMS"
+
+  private val defaultBaseUrl = "https://github.com/bulent2k2/scala-2/releases/download"
+
+  def baseUrlFor(version: String): String =
+    System.getProperty("kojo.toolchain.url", s"$defaultBaseUrl/v$version-tr").stripSuffix("/")
+
+  def cacheDir(version: String): File =
+    new File(s"${Utils.userDir}${File.separator}.kojo${File.separator}lite${File.separator}scala-tr", version)
+
+  /** True when every jar of the toolchain is present in `dir`. */
+  def isComplete(dir: File): Boolean =
+    dir.isDirectory && jarNames.forall(n => new File(dir, n).isFile)
+
+  /**
+   * Returns a directory holding the Turkish toolchain for `version`, fetching
+   * it first if it is not cached yet. None if it could not be made available -
+   * the caller then stays on the stock toolchain.
+   */
+  def ensureAvailable(version: String, progress: FetchProgress = ConsoleProgress): Option[File] = {
+    val dir = cacheDir(version)
+    if (isComplete(dir)) Some(dir)
+    else
+      try fetchInto(dir, version, progress)
+      catch {
+        case e: Throwable =>
+          progress.message(s"[WARNING] Could not fetch the Turkish Scala toolchain: ${e.getMessage}")
+          None
+      }
+      finally {
+        discardPartials(dir)
+        progress.finished()
+      }
+  }
+
+  /** Removes anything a failed fetch left half-written. */
+  private def discardPartials(dir: File): Unit =
+    Option(dir.listFiles).foreach(_.filter(_.getName.endsWith(".part")).foreach(_.delete()))
+
+  private def fetchInto(dir: File, version: String, progress: FetchProgress): Option[File] = {
+    val base = baseUrlFor(version)
+    progress.message(s"[INFO] Fetching the Turkish Scala toolchain $version from $base")
+    dir.mkdirs()
+    val expected = checksums(s"$base/$checksumFileName")
+    val staged = jarNames.map { name =>
+      val want = expected.getOrElse(
+        name,
+        throw new RuntimeException(s"$checksumFileName has no entry for $name")
+      )
+      val tmp = new File(dir, s"$name.part")
+      val actual = download(new URL(s"$base/$name"), tmp, name, progress)
+      if (!actual.equalsIgnoreCase(want)) {
+        tmp.delete()
+        throw new RuntimeException(s"checksum mismatch for $name (got $actual, expected $want)")
+      }
+      verifyZip(tmp, name)
+      if (name == "scala-library.jar") verifyScalaVersion(tmp, version)
+      (tmp, new File(dir, name))
+    }
+    // only publish the jars into their final names once all of them are good,
+    // so an interrupted fetch can never leave a half-usable toolchain behind
+    staged.foreach { case (tmp, target) => if (!tmp.renameTo(target)) throw new RuntimeException(s"cannot install $target") }
+    progress.message(s"[INFO] Turkish Scala toolchain ready in $dir")
+    Some(dir)
+  }
+
+  private def checksums(url: String): Map[String, String] = {
+    val src = Source.fromURL(new URL(url), "UTF-8")
+    try
+      src
+        .getLines()
+        .map(_.trim)
+        .filter(_.nonEmpty)
+        .flatMap { line =>
+          // "<sha256>  <filename>", as produced by sha256sum
+          line.split("\\s+").toList match {
+            case sum :: name :: Nil => Some(new File(name).getName -> sum)
+            case _                  => None
+          }
+        }
+        .toMap
+    finally src.close()
+  }
+
+  /** Downloads `url` into `target`, returning the SHA-256 of what arrived. */
+  private def download(url: URL, target: File, name: String, progress: FetchProgress): String = {
+    val digest = MessageDigest.getInstance("SHA-256")
+    val conn = url.openConnection()
+    progress.startJar(name, conn.getContentLengthLong)
+    val in: InputStream = conn.getInputStream
+    try {
+      val out = new FileOutputStream(target)
+      try {
+        val buf = new Array[Byte](64 * 1024)
+        var n = in.read(buf)
+        while (n > 0) {
+          digest.update(buf, 0, n)
+          out.write(buf, 0, n)
+          progress.bytes(n.toLong)
+          n = in.read(buf)
+        }
+      }
+      finally out.close()
+    }
+    finally in.close()
+    digest.digest().map(b => f"$b%02x").mkString
+  }
+
+  private def verifyZip(jar: File, name: String): Unit = {
+    val zf = new ZipFile(jar)
+    try if (zf.size == 0) throw new RuntimeException(s"$name is empty")
+    finally zf.close()
+  }
+
+  private def verifyScalaVersion(libraryJar: File, wanted: String): Unit = {
+    val zf = new ZipFile(libraryJar)
+    try {
+      val entry = Option(zf.getEntry("library.properties"))
+        .getOrElse(throw new RuntimeException("scala-library.jar has no library.properties"))
+      val props = new java.util.Properties()
+      val is = zf.getInputStream(entry)
+      try props.load(is)
+      finally is.close()
+      val got = props.getProperty("version.number", "<unknown>")
+      // the pack build stamps a suffix (2.13.18-20260823-...), so compare the release part
+      if (!got.startsWith(wanted)) {
+        throw new RuntimeException(s"toolchain is Scala $got, but Kojo needs $wanted")
+      }
+    }
+    finally zf.close()
+  }
+}

--- a/src/main/scala/net/kogics/kojo/lite/StubMain.scala
+++ b/src/main/scala/net/kogics/kojo/lite/StubMain.scala
@@ -198,12 +198,25 @@ trait StubMain {
     // allow another way to customize classpath
     val kojoCp = System.getenv("KOJO_CLASSPATH")
     if (kojoCp != null) {
+      // KOJO_CLASSPATH is set deliberately, so a toolchain jar in it is honored -
+      // but it shadows Kojo's own Scala jars, so say so
+      val (strays, _) = ScalaToolchainCheck.partitionStrays(kojoCp.split(File.pathSeparatorChar).toList)
+      strays.foreach { s =>
+        log(s"[WARNING] KOJO_CLASSPATH has a Scala toolchain jar that will shadow Kojo's own: $s")
+      }
       ourCp.append(kojoCp)
       ourCp.append(File.pathSeparatorChar)
     }
 
     def addJars(dir: String): Unit = {
-      Utils.filesInDir(dir, "jar").foreach { x =>
+      // user jars are prepended, so a Scala toolchain jar among them would shadow
+      // Kojo's own and break the compiler with a version mix - skip those
+      val (strays, jars) = ScalaToolchainCheck.partitionStrays(Utils.filesInDir(dir, "jar"))
+      strays.foreach { s =>
+        log(s"[WARNING] Ignoring stray Scala toolchain jar in $dir: $s " +
+          "(it would shadow Kojo's Scala toolchain; safe to delete)")
+      }
+      jars.foreach { x =>
         ourCp.append(dir)
         ourCp.append(File.separatorChar)
         ourCp.append(x)

--- a/src/test/scala/net/kogics/kojo/lite/ScalaToolchainCheckTest.scala
+++ b/src/test/scala/net/kogics/kojo/lite/ScalaToolchainCheckTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026
+ *   Bulent Basaran <ben@scala.org> https://github.com/bulent2k2
+ *
+ * The contents of this file are subject to the GNU General Public License
+ * Version 3 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.gnu.org/copyleft/gpl.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ */
+package net.kogics.kojo.lite
+
+import java.io.File
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FunSuite
+import org.scalatest.Matchers
+
+@RunWith(classOf[JUnitRunner])
+class ScalaToolchainCheckTest extends FunSuite with Matchers {
+  import ScalaToolchainCheck._
+
+  test("toolchain jar names are recognized, versioned or not") {
+    isToolchainJarName("scala-library.jar") should be(true)
+    isToolchainJarName("scala-library-2.13.3.jar") should be(true)
+    isToolchainJarName("scala-reflect-2.13.18.jar") should be(true)
+    isToolchainJarName("scala-compiler.jar") should be(true)
+    isToolchainJarName("scalariform.jar") should be(true)
+  }
+
+  test("jars that merely start with the same letters are left alone") {
+    isToolchainJarName("scala-swing_2.13-2.1.1.jar") should be(false)
+    isToolchainJarName("scala-xml_2.13-1.2.0.jar") should be(false)
+    isToolchainJarName("scala-parser-combinators_2.13-1.1.2.jar") should be(false)
+    isToolchainJarName("scala-parallel-collections_2.13-1.2.0.jar") should be(false)
+    isToolchainJarName("scalatest_2.13-3.0.8.jar") should be(false)
+    isToolchainJarName("scalactic_2.13-3.0.8.jar") should be(false)
+    isToolchainJarName("kojo.jar") should be(false)
+    isToolchainJarName("scala-library") should be(false) // not a jar
+  }
+
+  test("stray toolchain jars are separated from the rest of a user jar directory") {
+    val entries = List("myextension.jar", "scala-library-2.13.3.jar", "scalatest_2.13-3.0.8.jar", "scalariform.jar")
+    val (strays, rest) = partitionStrays(entries)
+    strays should be(List("scala-library-2.13.3.jar", "scalariform.jar"))
+    rest should be(List("myextension.jar", "scalatest_2.13-3.0.8.jar"))
+  }
+
+  test("entries are matched on the file name, not the path") {
+    val nested = List(
+      s"${File.separator}home${File.separator}u${File.separator}.kojo${File.separator}lite${File.separator}libk${File.separator}scala-compiler-2.13.3.jar",
+      s"${File.separator}opt${File.separator}scala-library${File.separator}mylib.jar"
+    )
+    val (strays, rest) = partitionStrays(nested)
+    strays.size should be(1)
+    strays.head should endWith("scala-compiler-2.13.3.jar")
+    rest.size should be(1) // a directory named scala-library must not trip the check
+  }
+
+  test("versionMismatch is quiet on a consistent toolchain") {
+    // the test JVM runs on one toolchain, so this must not fire
+    versionMismatch should be(None)
+  }
+}

--- a/src/test/scala/net/kogics/kojo/lite/ScalaToolchainFetcherTest.scala
+++ b/src/test/scala/net/kogics/kojo/lite/ScalaToolchainFetcherTest.scala
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2026
+ *   Bulent Basaran <ben@scala.org> https://github.com/bulent2k2
+ *
+ * The contents of this file are subject to the GNU General Public License
+ * Version 3 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.gnu.org/copyleft/gpl.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ */
+package net.kogics.kojo.lite
+
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FunSuite
+import org.scalatest.Matchers
+
+/**
+ * Drives the whole on-demand fetch path against a local directory served over
+ * file://, so the tests never touch the network.
+ */
+@RunWith(classOf[JUnitRunner])
+class ScalaToolchainFetcherTest extends FunSuite with Matchers {
+  val version = "2.13.18"
+
+  def sha256(f: File): String = {
+    val digest = MessageDigest.getInstance("SHA-256")
+    digest.digest(Files.readAllBytes(f.toPath)).map(b => f"$b%02x").mkString
+  }
+
+  /** A minimal but real jar; scala-library.jar gets a library.properties. */
+  def makeJar(dir: File, name: String, scalaVersion: Option[String]): File = {
+    val jar = new File(dir, name)
+    val zos = new ZipOutputStream(new FileOutputStream(jar))
+    try {
+      zos.putNextEntry(new ZipEntry("marker.txt"))
+      zos.write(s"$name for test".getBytes("UTF-8"))
+      zos.closeEntry()
+      scalaVersion.foreach { v =>
+        zos.putNextEntry(new ZipEntry("library.properties"))
+        zos.write(s"version.number=$v\nmaven.version.number=$v\n".getBytes("UTF-8"))
+        zos.closeEntry()
+      }
+    }
+    finally zos.close()
+    jar
+  }
+
+  /** Builds a fake release directory, with SHA256SUMS, and returns its file:// URL. */
+  def publish(libraryVersion: String = s"$version-20260823-123456-abcdef0"): (File, String) = {
+    val remote = Files.createTempDirectory("kojo-toolchain-remote").toFile
+    val jars = ScalaToolchainFetcher.jarNames.map { n =>
+      makeJar(remote, n, if (n == "scala-library.jar") Some(libraryVersion) else None)
+    }
+    val sums = jars.map(j => s"${sha256(j)}  ${j.getName}").mkString("\n") + "\n"
+    Files.write(new File(remote, ScalaToolchainFetcher.checksumFileName).toPath, sums.getBytes("UTF-8"))
+    (remote, remote.toURI.toString)
+  }
+
+  def withRemote(url: String)(body: => Unit): Unit = {
+    val old = System.getProperty("kojo.toolchain.url")
+    try {
+      System.setProperty("kojo.toolchain.url", url)
+      body
+    }
+    finally {
+      if (old == null) System.clearProperty("kojo.toolchain.url") else System.setProperty("kojo.toolchain.url", old)
+    }
+  }
+
+  /** ensureAvailable caches under the user's home; run each case in its own version dir. */
+  def freshVersion(tag: String): String = s"$version-test-$tag"
+
+  test("a published toolchain is fetched, verified and installed") {
+    val v = freshVersion("ok")
+    val (remote, url) = publish(s"$v-20260823-123456-abcdef0")
+    val dir = ScalaToolchainFetcher.cacheDir(v)
+    deleteRecursively(dir)
+    withRemote(url) {
+      val got = ScalaToolchainFetcher.ensureAvailable(v, silent)
+      got.isDefined should be(true)
+      ScalaToolchainFetcher.isComplete(got.get) should be(true)
+      // nothing half-written left behind
+      got.get.listFiles.count(_.getName.endsWith(".part")) should be(0)
+    }
+    deleteRecursively(remote)
+    deleteRecursively(dir)
+  }
+
+  test("the download reports each jar and its bytes") {
+    val v = freshVersion("progress")
+    val (remote, url) = publish(s"$v-20260823-123456-abcdef0")
+    val dir = ScalaToolchainFetcher.cacheDir(v)
+    deleteRecursively(dir)
+    val recorder = new Recorder
+    withRemote(url) {
+      ScalaToolchainFetcher.ensureAvailable(v, recorder).isDefined should be(true)
+    }
+    recorder.jars.map(_._1) should be(ScalaToolchainFetcher.jarNames)
+    recorder.jars.foreach { case (_, total) => total should be > 0L }
+    recorder.received should be(ScalaToolchainFetcher.jarNames.map(n => new File(dir, n).length).sum)
+    recorder.finishedCalls should be(1)
+    deleteRecursively(remote)
+    deleteRecursively(dir)
+  }
+
+  test("an already cached toolchain is used without fetching") {
+    val v = freshVersion("cached")
+    val dir = ScalaToolchainFetcher.cacheDir(v)
+    deleteRecursively(dir)
+    dir.mkdirs()
+    ScalaToolchainFetcher.jarNames.foreach(n => makeJar(dir, n, None))
+    withRemote("file:///nonexistent-so-a-fetch-would-fail/") {
+      ScalaToolchainFetcher.ensureAvailable(v, silent) should be(Some(dir))
+    }
+    deleteRecursively(dir)
+  }
+
+  test("a tampered jar is rejected and nothing is installed") {
+    val (remote, url) = publish()
+    // corrupt one jar after the checksums were published
+    Files.write(new File(remote, "scala-reflect.jar").toPath, "not the jar you signed".getBytes("UTF-8"))
+    val v = freshVersion("tampered")
+    val dir = ScalaToolchainFetcher.cacheDir(v)
+    deleteRecursively(dir)
+    withRemote(url) {
+      ScalaToolchainFetcher.ensureAvailable(v, silent) should be(None)
+    }
+    ScalaToolchainFetcher.isComplete(dir) should be(false)
+    // and no half-written file is left lying around
+    Option(dir.listFiles).getOrElse(Array.empty).count(_.getName.endsWith(".part")) should be(0)
+    deleteRecursively(remote)
+    deleteRecursively(dir)
+  }
+
+  test("a toolchain built for another Scala release is rejected") {
+    val (remote, url) = publish("2.13.15-20230909-175640-c8d4123")
+    val v = freshVersion("wrongversion")
+    val dir = ScalaToolchainFetcher.cacheDir(v)
+    deleteRecursively(dir)
+    withRemote(url) {
+      ScalaToolchainFetcher.ensureAvailable(v, silent) should be(None)
+    }
+    ScalaToolchainFetcher.isComplete(dir) should be(false)
+    deleteRecursively(remote)
+    deleteRecursively(dir)
+  }
+
+  test("an unreachable download leaves no cache and reports the reason") {
+    val v = freshVersion("offline")
+    val dir = ScalaToolchainFetcher.cacheDir(v)
+    deleteRecursively(dir)
+    val recorder = new Recorder
+    withRemote("file:///definitely/not/here/") {
+      ScalaToolchainFetcher.ensureAvailable(v, recorder) should be(None)
+    }
+    recorder.messages.exists(_.contains("[WARNING]")) should be(true)
+    recorder.finishedCalls should be(1)
+    ScalaToolchainFetcher.isComplete(dir) should be(false)
+    deleteRecursively(dir)
+  }
+
+  /** Records what the fetcher reports, so progress is covered too. */
+  class Recorder extends FetchProgress {
+    val messages = collection.mutable.ListBuffer.empty[String]
+    val jars = collection.mutable.ListBuffer.empty[(String, Long)]
+    var received = 0L
+    var finishedCalls = 0
+    def message(msg: String): Unit = messages += msg
+    def startJar(name: String, totalBytes: Long): Unit = jars += (name -> totalBytes)
+    def bytes(n: Long): Unit = received += n
+    def finished(): Unit = finishedCalls += 1
+  }
+
+  val silent = new Recorder
+
+  def deleteRecursively(f: File): Unit = {
+    if (f.isDirectory) Option(f.listFiles).foreach(_.foreach(deleteRecursively))
+    f.delete()
+  }
+}

--- a/src/test/scala/net/kogics/kojo/lite/ScalaToolchainTest.scala
+++ b/src/test/scala/net/kogics/kojo/lite/ScalaToolchainTest.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026
+ *   Bulent Basaran <ben@scala.org> https://github.com/bulent2k2
+ *
+ * The contents of this file are subject to the GNU General Public License
+ * Version 3 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.gnu.org/copyleft/gpl.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ */
+package net.kogics.kojo.lite
+
+import java.io.File
+import java.nio.file.Files
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FunSuite
+import org.scalatest.Matchers
+
+@RunWith(classOf[JUnitRunner])
+class ScalaToolchainTest extends FunSuite with Matchers {
+
+  // lib/{scala-en,scala-tr} dirs with toolchain jars, plus a regular jar in lib.
+  // deleteOnExit deletes in reverse registration order, so register each parent
+  // before its children and the whole tree is cleaned up at JVM exit.
+  def makeLibDir(): File = {
+    val lib = Files.createTempDirectory("kojo-toolchain-test").toFile
+    lib.deleteOnExit()
+    val toolchainJars = Seq("scala-library.jar", "scala-reflect.jar", "scala-compiler.jar", "scalariform.jar")
+    Seq(ScalaToolchain.englishDirName, ScalaToolchain.turkishDirName).foreach { variant =>
+      val dir = new File(lib, variant)
+      dir.mkdirs()
+      dir.deleteOnExit()
+      toolchainJars.foreach { name =>
+        val jar = new File(dir, name)
+        jar.createNewFile()
+        jar.deleteOnExit()
+      }
+    }
+    val kojoJar = new File(lib, "kojo.jar")
+    kojoJar.createNewFile()
+    kojoJar.deleteOnExit()
+    lib
+  }
+
+  def launcherCp(lib: File): List[String] = {
+    val enDir = new File(lib, ScalaToolchain.englishDirName)
+    new File(lib, "kojo.jar").getPath :: enDir.listFiles.map(_.getPath).toList
+  }
+
+  test("classpath without toolchain dirs is left unchanged (dev mode)") {
+    val cp = List("/some/place/scala-library.jar", "/some/place/kojo.jar")
+    ScalaToolchain.select(cp, ScalaToolchain.turkishDirName) should be(cp)
+  }
+
+  test("selecting the Turkish variant swaps the toolchain jars") {
+    val lib = makeLibDir()
+    val selected = ScalaToolchain.select(launcherCp(lib), ScalaToolchain.turkishDirName)
+    val trDir = new File(lib, ScalaToolchain.turkishDirName).getPath
+    selected.filter(_.endsWith("scala-compiler.jar")) should be(List(s"$trDir${File.separator}scala-compiler.jar"))
+    selected.count(_.contains(ScalaToolchain.englishDirName)) should be(0)
+    selected should contain(new File(lib, "kojo.jar").getPath)
+  }
+
+  test("selecting the English variant keeps the stock toolchain jars") {
+    val lib = makeLibDir()
+    val selected = ScalaToolchain.select(launcherCp(lib), ScalaToolchain.englishDirName)
+    val enDir = new File(lib, ScalaToolchain.englishDirName).getPath
+    selected.filter(_.endsWith("scala-compiler.jar")) should be(List(s"$enDir${File.separator}scala-compiler.jar"))
+    selected.count(_.contains(ScalaToolchain.turkishDirName)) should be(0)
+  }
+
+  test("missing variant dir leaves the classpath unchanged") {
+    val lib = makeLibDir()
+    val cp = launcherCp(lib)
+    ScalaToolchain.select(cp, "scala-xx") should be(cp)
+  }
+
+  test("toolchain jars come before the other jars") {
+    val lib = makeLibDir()
+    val selected = ScalaToolchain.select(launcherCp(lib), ScalaToolchain.turkishDirName)
+    selected.indexWhere(_.endsWith("scala-library.jar")) should be < selected.indexOf(new File(lib, "kojo.jar").getPath)
+  }
+
+  test("kojo.toolchain overrides the language-based choice") {
+    val old = System.getProperty("kojo.toolchain")
+    try {
+      System.setProperty("kojo.toolchain", "tr")
+      ScalaToolchain.variantDirName should be(ScalaToolchain.turkishDirName)
+      System.setProperty("kojo.toolchain", "en")
+      ScalaToolchain.variantDirName should be(ScalaToolchain.englishDirName)
+    }
+    finally {
+      if (old == null) System.clearProperty("kojo.toolchain") else System.setProperty("kojo.toolchain", old)
+    }
+  }
+}

--- a/stage-i4j-installer
+++ b/stage-i4j-installer
@@ -11,6 +11,10 @@ cd installer
 scala cp-staging-jars.scala
 cd ..
 
+# Stage the stock Scala toolchain into lib/scala-en; the launcher boots on it.
+# The Turkish-keyword toolchain is not packaged - it is fetched on demand.
+./stage-scala-toolchains.sh installerbuild/lib
+
 cp -va installer/* installerbuild/
 cd installerbuild
 rm *.*

--- a/stage-scala-toolchains.sh
+++ b/stage-scala-toolchains.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Stages the stock Scala toolchain into <arg1>/scala-en (default arg1:
+# installerbuild/lib): scala-library/reflect/compiler downloaded from Maven
+# Central at build.sbt's scalaVer, plus scalariform from lib/.
+#
+# The launcher boots on this directory and, for a Turkish user, swaps in a
+# lib/scala-tr with the Turkish-keyword compiler - which is not packaged here
+# and is fetched on demand instead; see net.kogics.kojo.lite.ScalaToolchain.
+#
+# Runs from the repo root regardless of the caller's cwd; a relative <arg1>
+# resolves against the repo root.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+libdir=${1:-installerbuild/lib}
+scalaVer=$(sed -n 's/^lazy val scalaVer *= *"\([0-9][0-9.]*\)".*/\1/p' build.sbt)
+if [ -z "$scalaVer" ]; then
+  echo "Could not read scalaVer from build.sbt" >&2
+  exit 1
+fi
+cache=scala-en-jars/$scalaVer
+
+mkdir -p "$cache"
+for jar in scala-library scala-reflect scala-compiler; do
+  if [ ! -f "$cache/$jar.jar" ]; then
+    echo "Fetching $jar $scalaVer from Maven Central..."
+    curl -fL --retry 3 --retry-delay 2 -o "$cache/$jar.jar.tmp" \
+      "https://repo1.maven.org/maven2/org/scala-lang/$jar/$scalaVer/$jar-$scalaVer.jar"
+    unzip -tqq "$cache/$jar.jar.tmp" # integrity check: a truncated download fails here, not at runtime
+    mv "$cache/$jar.jar.tmp" "$cache/$jar.jar"
+  fi
+done
+
+mkdir -p "$libdir/scala-en"
+cp "$cache"/scala-library.jar "$cache"/scala-reflect.jar "$cache"/scala-compiler.jar "$libdir/scala-en/"
+cp lib/scalariform.jar "$libdir/scala-en/scalariform.jar"
+echo "Staged the Scala $scalaVer toolchain under $libdir/scala-en"


### PR DESCRIPTION
Refreshes the Turkish localization with the work done in [bulent2k2/kojo](https://github.com/bulent2k2/kojo) since you last absorbed it.

This branch is cut from **your current master**, not from the fork's, so none of the fork's unrelated drift comes along. 162 files, +8,345 / −4,153.

## What's here

- **`lite/i18n/tr/` — 40 modules, 13 new to this repo.** Joystick commands, `LazyList` and parallel-collection methods, `Array` and `Set` methods, type names and units (`Slow`, `Pixel`, `Cm`), month and weekday names, and the `Matematik` and `Yardımcı` handles.
- **Turkish diagnostics.** Compiler error messages, REPL type and output text, and code completion (Ctrl-Space), including Turkish colour and font names.
- **106 Turkish samples and installed examples**, 14 new — Mandelbrot showcase (single-threaded and parallel), Pong, Koch snowflake, analog/digital clock, sprite-boundary editor, and the `kojo-kilavuz` lesson set.
- **`Bundle_tr.properties`** and `i18n/initk/tr.*.kojo` updated to match.

## Touching your code

Nine files outside `i18n/` gain **28 lines between them**. Every one is a no-op unless `user.language == "tr"`: a call into the `i18n.tr` package for output, type and completion translation, plus the Turkish keyword and template lists in `CodeCompletionUtils` / `CodeTemplates`.

| file | hook lines |
|---|---:|
| `lite/KojoCompletionProvider.scala` | 6 |
| `lite/OutputPane.scala` | 4 |
| `xscala/Help.scala` | 4 |
| `lexer/ScalariformTokenMaker.scala` | 3 |
| `xscala/CodeCompletionUtils.scala` | 3 |
| `lite/ScriptEditor.scala` | 3 |
| `lite/CodeExecutionSupport.scala` | 3 |
| `xscala/CodeTemplates.scala` | 1 |
| `lite/i18n/LangInit.scala` | 1 |

The fork has other differences in those same files; I deliberately left them behind. Each file here is your current version plus the hook.

## One new dependency

`scala-parallel-collections` 1.2.0 — `lite/i18n/tr/dizin.scala` needs it. Nothing but the Turkish layer pulls it in.

## The samples need the Turkish-keyword compiler — please read this before merging

The Turkish **API** in this PR works on stock Scala. The Turkish **samples** do not. 103 of the 106 `.kojo` files here are written in the Turkish keywords (`dez`, `den`, `tanım`, `eğer`, `yoksa`, `nesne`), which only the patched compiler accepts. Stock Scala rejects them at the first line:

```
nesne T {
^ error: expected class or object definition
```

That matters more than it sounds, because `loadLocalizedResource` substitutes the `tr/` variant automatically for any sample menu item when the locale is Turkish — there is no separate Turkish submenu to avoid. Concretely: of the 87 sample files reachable from the menus, 79 have a Turkish variant here, and **75 of those use the Turkish keywords**. A Turkish user on a stock-Scala build would find most of Samples/Örnekler and Showcases/Sergi failing to run.

Nothing here breaks for anyone else. English and every other locale are untouched, and the samples are inert resources that only a Turkish user opens.

So this is best merged together with the opt-in toolchain PR (branch `upstream-turkish-toolchain`), which is what makes those samples run. **If you would rather not take the toolchain, say so and I will cut the samples out of this PR** — the API layer stands on its own and is useful without them.

## Testing

`./sbt.sh test` passes on this branch: **306 tests, 0 failures**, compiled with stock Scala 2.13.18 — no patched compiler involved anywhere in the build. `TurkishAPITest` covers the API surface.

Two notes if you reproduce it: the suite needs `--add-opens java.base/java.lang=ALL-UNNAMED` on Java 9+ for the cglib/jmock suites, and the Turkish sources need a UTF-8 locale for their non-ASCII file names.

Happy to split this further if any part is easier to review on its own.
