### PR TITLE
Ignore stale Scala jars in ~/.kojo/lite/libk that shadow Kojo's toolc…

### DIFF
--- a/src/main/scala/net/kogics/kojo/lite/Main.scala
+++ b/src/main/scala/net/kogics/kojo/lite/Main.scala
@@ -81,6 +81,10 @@ object Main extends AppMenu with ScriptLoader { main =>
 
     setupLogging()
     val Log = Logger.getLogger("Main")
+    ScalaToolchainCheck.versionMismatch.foreach { msg =>
+      Log.warning(msg)
+      System.err.println(s"[WARNING] $msg")
+    }
     if (!kojoCtx.subKojo) {
       runMultiInstancehandler()
     }

--- a/src/main/scala/net/kogics/kojo/lite/ScalaToolchainCheck.scala
+++ b/src/main/scala/net/kogics/kojo/lite/ScalaToolchainCheck.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026
+ *   Bulent Basaran <ben@scala.org> https://github.com/bulent2k2
+ *
+ * The contents of this file are subject to the GNU General Public License
+ * Version 3 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.gnu.org/copyleft/gpl.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ */
+package net.kogics.kojo.lite
+
+import java.io.File
+
+/**
+ * Guards against a stray Scala toolchain jar shadowing the one Kojo ships.
+ *
+ * `StubMain.createCp` puts user-supplied jars - from ~/.kojo/lite/libk, the
+ * extension dirs and KOJO_CLASSPATH - ahead of Kojo's own lib directory. A
+ * scala-library, scala-reflect, scala-compiler or scalariform jar sitting in
+ * one of those places therefore wins over Kojo's copy, and the mismatched
+ * pair fails much later, deep inside the compiler, with an inscrutable error
+ * (a scala-library-2.13.3.jar left in libk produced
+ * `NoSuchMethodError: MurmurHash3$.caseClassHash(...)` at startup).
+ *
+ * Two guards live here: a name test used to skip such jars while the
+ * classpath is being built, and a startup check that reports a toolchain
+ * that is already mixed, naming the jar each part came from.
+ */
+object ScalaToolchainCheck {
+  private val toolchainJarPrefixes = Seq("scala-library", "scala-reflect", "scala-compiler", "scalariform")
+
+  /**
+   * True for scala-library.jar, scala-library-2.13.3.jar and friends - but not
+   * for scala-swing_2.13-*.jar, scalatest_2.13-*.jar and other jars that merely
+   * start with the same letters.
+   */
+  def isToolchainJarName(name: String): Boolean =
+    name.endsWith(".jar") && toolchainJarPrefixes.exists { p =>
+      name == s"$p.jar" || name.startsWith(s"$p-")
+    }
+
+  /** Splits classpath entries into (toolchain jars, everything else). */
+  def partitionStrays(entries: List[String]): (List[String], List[String]) =
+    entries.partition(e => isToolchainJarName(new File(e).getName))
+
+
+  private def versionAt(url: String): Option[String] =
+    try {
+      val is = new java.net.URL(url).openStream()
+      try {
+        val props = new java.util.Properties()
+        props.load(is)
+        Option(props.getProperty("version.number")).filter(_.nonEmpty)
+      }
+      finally is.close()
+    }
+    catch { case _: Throwable => None }
+
+  private def part(name: String, propsFile: String, preferInUrl: String): Option[(String, String, String)] = {
+    val urls = collection.mutable.ListBuffer.empty[String]
+    val e = getClass.getClassLoader.getResources(propsFile)
+    while (e.hasMoreElements) urls += e.nextElement.toString
+    // upstream's scalariform.jar bundles its own (2.13.0) library.properties, so the
+    // first hit for a properties file is not always the artifact we are asking about
+    val url = urls.find(_.contains(preferInUrl)).orElse(urls.headOption)
+    url.flatMap(u => versionAt(u).map(v => (name, v, u)))
+  }
+
+  /**
+   * Detects a mixed Scala toolchain - a scala-library, scala-reflect and
+   * scala-compiler of different versions resolving from different jars.
+   * Reports the jar each part came from, without loading the compiler's
+   * heavyweight classes just to ask.
+   */
+  def versionMismatch: Option[String] =
+    try {
+      val parts = Seq(
+        part("scala-library", "library.properties", "scala-library"),
+        part("scala-reflect", "reflect.properties", "scala-reflect"),
+        part("scala-compiler", "compiler.properties", "scala-compiler")
+      ).flatten
+
+      if (parts.map(_._2).distinct.size <= 1) None
+      else
+        Some(
+          "Mixed Scala toolchain on the classpath - Kojo will likely fail to compile scripts:\n" +
+            parts.map { case (name, version, source) => s"  $name $version from $source" }.mkString("\n") +
+            "\nRemove the stray jar(s) - check ~/.kojo/lite/libk, ~/.kojo/extension, the KOJO_CLASSPATH " +
+            "environment variable, and old scala jars in the install's lib directory."
+        )
+    }
+    catch {
+      // a broken classpath is exactly what this check looks for; it must not
+      // fail startup itself while trying to describe one
+      case _: Throwable => None
+    }
+
+}

--- a/src/main/scala/net/kogics/kojo/lite/ScalaToolchainCheck.scala
+++ b/src/main/scala/net/kogics/kojo/lite/ScalaToolchainCheck.scala
@@ -36,13 +36,13 @@ object ScalaToolchainCheck {
   private val toolchainJarPrefixes = Seq("scala-library", "scala-reflect", "scala-compiler", "scalariform")
 
   /**
-   * True for scala-library.jar, scala-library-2.13.3.jar and friends - but not
-   * for scala-swing_2.13-*.jar, scalatest_2.13-*.jar and other jars that merely
-   * start with the same letters.
+   * True for scala-library.jar, scala-library-2.13.3.jar, and Maven-style names
+   * like scalariform_2.13-0.2.10.jar - but not for scala-swing_2.13-*.jar,
+   * scalatest_2.13-*.jar and other jars that merely start with the same letters.
    */
   def isToolchainJarName(name: String): Boolean =
     name.endsWith(".jar") && toolchainJarPrefixes.exists { p =>
-      name == s"$p.jar" || name.startsWith(s"$p-")
+      name == s"$p.jar" || name.startsWith(s"$p-") || name.startsWith(s"${p}_")
     }
 
   /** Splits classpath entries into (toolchain jars, everything else). */
@@ -74,7 +74,10 @@ object ScalaToolchainCheck {
 
   /**
    * Detects a mixed Scala toolchain - a scala-library, scala-reflect and
-   * scala-compiler of different versions resolving from different jars.
+   * scala-compiler of different versions resolving from different jars. A
+   * version match is necessary but not sufficient: two builds can report the
+   * same version yet differ in generated code, and that mix stays invisible
+   * here - the name-based guards above are the defense for that case.
    * Reports the jar each part came from, without loading the compiler's
    * heavyweight classes just to ask.
    */

--- a/src/main/scala/net/kogics/kojo/lite/StubMain.scala
+++ b/src/main/scala/net/kogics/kojo/lite/StubMain.scala
@@ -198,12 +198,25 @@ trait StubMain {
     // allow another way to customize classpath
     val kojoCp = System.getenv("KOJO_CLASSPATH")
     if (kojoCp != null) {
+      // KOJO_CLASSPATH is set deliberately, so a toolchain jar in it is honored -
+      // but it shadows Kojo's own Scala jars, so say so
+      val (strays, _) = ScalaToolchainCheck.partitionStrays(kojoCp.split(File.pathSeparatorChar).toList)
+      strays.foreach { s =>
+        log(s"[WARNING] KOJO_CLASSPATH has a Scala toolchain jar that will shadow Kojo's own: $s")
+      }
       ourCp.append(kojoCp)
       ourCp.append(File.pathSeparatorChar)
     }
 
     def addJars(dir: String): Unit = {
-      Utils.filesInDir(dir, "jar").foreach { x =>
+      // user jars are prepended, so a Scala toolchain jar among them would shadow
+      // Kojo's own and break the compiler with a version mix - skip those
+      val (strays, jars) = ScalaToolchainCheck.partitionStrays(Utils.filesInDir(dir, "jar"))
+      strays.foreach { s =>
+        log(s"[WARNING] Ignoring stray Scala toolchain jar in $dir: $s " +
+          "(it would shadow Kojo's Scala toolchain; safe to delete)")
+      }
+      jars.foreach { x =>
         ourCp.append(dir)
         ourCp.append(File.separatorChar)
         ourCp.append(x)

--- a/src/test/scala/net/kogics/kojo/lite/ScalaToolchainCheckTest.scala
+++ b/src/test/scala/net/kogics/kojo/lite/ScalaToolchainCheckTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026
+ *   Bulent Basaran <ben@scala.org> https://github.com/bulent2k2
+ *
+ * The contents of this file are subject to the GNU General Public License
+ * Version 3 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.gnu.org/copyleft/gpl.html
+ *
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ */
+package net.kogics.kojo.lite
+
+import java.io.File
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FunSuite
+import org.scalatest.Matchers
+
+@RunWith(classOf[JUnitRunner])
+class ScalaToolchainCheckTest extends FunSuite with Matchers {
+  import ScalaToolchainCheck._
+
+  test("toolchain jar names are recognized, versioned or not") {
+    isToolchainJarName("scala-library.jar") should be(true)
+    isToolchainJarName("scala-library-2.13.3.jar") should be(true)
+    isToolchainJarName("scala-reflect-2.13.18.jar") should be(true)
+    isToolchainJarName("scala-compiler.jar") should be(true)
+    isToolchainJarName("scalariform.jar") should be(true)
+  }
+
+  test("jars that merely start with the same letters are left alone") {
+    isToolchainJarName("scala-swing_2.13-2.1.1.jar") should be(false)
+    isToolchainJarName("scala-xml_2.13-1.2.0.jar") should be(false)
+    isToolchainJarName("scala-parser-combinators_2.13-1.1.2.jar") should be(false)
+    isToolchainJarName("scala-parallel-collections_2.13-1.2.0.jar") should be(false)
+    isToolchainJarName("scalatest_2.13-3.0.8.jar") should be(false)
+    isToolchainJarName("scalactic_2.13-3.0.8.jar") should be(false)
+    isToolchainJarName("kojo.jar") should be(false)
+    isToolchainJarName("scala-library") should be(false) // not a jar
+  }
+
+  test("stray toolchain jars are separated from the rest of a user jar directory") {
+    val entries = List("myextension.jar", "scala-library-2.13.3.jar", "scalatest_2.13-3.0.8.jar", "scalariform.jar")
+    val (strays, rest) = partitionStrays(entries)
+    strays should be(List("scala-library-2.13.3.jar", "scalariform.jar"))
+    rest should be(List("myextension.jar", "scalatest_2.13-3.0.8.jar"))
+  }
+
+  test("entries are matched on the file name, not the path") {
+    val nested = List(
+      s"${File.separator}home${File.separator}u${File.separator}.kojo${File.separator}lite${File.separator}libk${File.separator}scala-compiler-2.13.3.jar",
+      s"${File.separator}opt${File.separator}scala-library${File.separator}mylib.jar"
+    )
+    val (strays, rest) = partitionStrays(nested)
+    strays.size should be(1)
+    strays.head should endWith("scala-compiler-2.13.3.jar")
+    rest.size should be(1) // a directory named scala-library must not trip the check
+  }
+
+  test("versionMismatch is quiet on a consistent toolchain") {
+    // the test JVM runs on one toolchain, so this must not fire
+    versionMismatch should be(None)
+  }
+}

--- a/src/test/scala/net/kogics/kojo/lite/ScalaToolchainCheckTest.scala
+++ b/src/test/scala/net/kogics/kojo/lite/ScalaToolchainCheckTest.scala
@@ -32,6 +32,8 @@ class ScalaToolchainCheckTest extends FunSuite with Matchers {
     isToolchainJarName("scala-reflect-2.13.18.jar") should be(true)
     isToolchainJarName("scala-compiler.jar") should be(true)
     isToolchainJarName("scalariform.jar") should be(true)
+    isToolchainJarName("scalariform_2.13-0.2.10.jar") should be(true)
+    isToolchainJarName("scala-library_2.13-x.jar") should be(true)
   }
 
   test("jars that merely start with the same letters are left alone") {


### PR DESCRIPTION
…hain

A user's Kojo died at startup with

  NoSuchMethodError: scala.util.hashing.MurmurHash3$.caseClassHash(...)

caused by a scala-library-2.13.3.jar left in ~/.kojo/lite/libk. createCp prepends the jars found there, so the old library shadowed Kojo's own and was paired with a current scala-reflect, whose Types$UniqueType.hashCode calls a method 2.13.3 does not have.

Two guards:

- createCp skips scala-library/reflect/compiler/scalariform jars (versioned names included) found in ~/.kojo/lite/libk and the extension dirs, with a warning naming each one. A toolchain jar in a user directory can only shadow Kojo's own. KOJO_CLASSPATH is set deliberately, so entries there are honored, but a toolchain jar in it is still called out.
- ScalaToolchainCheck.versionMismatch, called from Main once logging is set up, compares the scala-library, scala-reflect and scala-compiler versions actually resolving on the classpath and names the jar each came from, turning a crash deep inside the compiler into a startup warning that says which file to delete.

The version lookup reads each version from the jar the properties file actually came from, because lib/scalariform.jar bundles its own (2.13.0) library.properties: a plain classloader lookup - including scala.util.Properties.versionNumberString - reports 2.13.0 for the library in Kojo's own classpath. The whole check is wrapped so a broken classpath can never make the check itself fail startup.

Tested: 308 tests pass. The name matcher is covered including the near-misses (scala-swing_2.13-*, scalatest_2.13-*, scalactic_2.13-*), and the mismatch report was verified against the reported combination - scala-library 2.13.3 with a 2.13.18 reflect and compiler in one JVM - where it names all three jars with their versions and paths.